### PR TITLE
Añadida lógica para mostrar sesiones completadas y mostrar plan actual y el anterior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,21 @@
         "@nestjs/config": "^4.0.2",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.513.0",
+        "recharts": "^2.15.3",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
-        "@types/jwt-decode": "^3.1.0"
+        "@types/jwt-decode": "^3.1.0",
+        "@types/recharts": "^1.8.29"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -97,6 +108,69 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/jwt-decode": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-3.1.0.tgz",
@@ -105,6 +179,180 @@
       "dev": true,
       "dependencies": {
         "jwt-decode": "*"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/recharts": {
+      "version": "1.8.29",
+      "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.29.tgz",
+      "integrity": "sha512-ulKklaVsnFIIhTQsQw226TnOibrddW1qUQNFVhoQEyY1Z7FRQrNecFCGt7msRuJseudzE9czVawZb17dK/aPXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^1",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/recharts/node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/recharts/node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -123,6 +371,22 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dotenv": {
@@ -150,6 +414,21 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/fflate": {
@@ -199,6 +478,15 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/iterare": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
@@ -208,6 +496,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
@@ -243,6 +537,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.513.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
@@ -258,6 +564,32 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -265,6 +597,88 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect-metadata": {
@@ -284,6 +698,13 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/strtok3": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
@@ -300,6 +721,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/token-types": {
       "version": "6.0.0",
@@ -350,6 +777,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
     "@nestjs/config": "^4.0.2",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.513.0",
+    "recharts": "^2.15.3",
     "zustand": "^5.0.5"
   },
   "devDependencies": {
-    "@types/jwt-decode": "^3.1.0"
+    "@types/jwt-decode": "^3.1.0",
+    "@types/recharts": "^1.8.29"
   }
 }

--- a/switkor-backend/src/training-plan/training-plan.controller.ts
+++ b/switkor-backend/src/training-plan/training-plan.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Post, Body, UseGuards, Get } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Get, Req } from '@nestjs/common';
 import { TrainingPlanService } from './training-plan.service';
 import { CreatePlanDto } from './dto/create-plan.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { User } from '../user/user.entity';
+import { AuthenticatedRequest } from '../types/express';
 
 @Controller('plan')
 export class TrainingPlanController {
@@ -25,5 +26,12 @@ export class TrainingPlanController {
   @Get('all')
   async getAllPlans(@CurrentUser() user: User) {
     return this.trainingPlanService.getAllPlansForUser(user);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('/current-and-previous')
+  async getCurrentAndPreviousPlans(@Req() req: AuthenticatedRequest) {
+    const user = req.user;
+    return this.trainingPlanService.getCurrentAndPreviousPlans(user);
   }
 }

--- a/switkor-backend/src/training-plan/training-plan.service.ts
+++ b/switkor-backend/src/training-plan/training-plan.service.ts
@@ -47,7 +47,7 @@ export class TrainingPlanService {
         trainingPlan: {
           user: { id: user.id },
         },
-        date: MoreThanOrEqual(new Date()),
+        date: MoreThanOrEqual(startDate),
       },
       relations: ['trainingPlan', 'trainingPlan.user'],
     });
@@ -404,4 +404,20 @@ const savedSessions = generatedMaps as TrainingSession[];
       ],
     });
   }
+
+  async getCurrentAndPreviousPlans(user: User): Promise<TrainingPlan[]> {
+  return this.planRepo.find({
+    where: {
+      user: { id: user.id },
+    },
+    order: { startDate: 'DESC' },
+    take: 2,
+    relations: [
+      'sessions',
+      'sessions.exercises',
+      'sessions.exercises.exercise',
+    ],
+  });
+}
+
 }

--- a/switkor-backend/src/training-session/training-session.controller.ts
+++ b/switkor-backend/src/training-session/training-session.controller.ts
@@ -1,19 +1,27 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards, Patch } from '@nestjs/common';
 import { TrainingSessionService } from './training-session.service';
 import { AuthGuard } from '@nestjs/passport';
 import { NotFoundException } from '@nestjs/common';
 
 @Controller('session')
 export class TrainingSessionController {
-  constructor(private readonly trainingSessionService: TrainingSessionService) {}
+  constructor(
+    private readonly trainingSessionService: TrainingSessionService,
+  ) {}
 
   @UseGuards(AuthGuard('jwt'))
   @Get(':id')
   async getSessionById(@Param('id') id: number) {
-     const session = await this.trainingSessionService.getSessionById(Number(id));
-  if (!session) {
-    throw new NotFoundException('Sesión no encontrada');
+    const session = await this.trainingSessionService.getSessionById(
+      Number(id),
+    );
+    if (!session) {
+      throw new NotFoundException('Sesión no encontrada');
+    }
+    return session;
   }
-  return session;
+  @Patch(':id/complete')
+  async completeSession(@Param('id') id: string) {
+    return this.trainingSessionService.markComplete(+id);
   }
 }

--- a/switkor-backend/src/training-session/training-session.controller.ts
+++ b/switkor-backend/src/training-session/training-session.controller.ts
@@ -12,6 +12,12 @@ export class TrainingSessionController {
   ) {}
 
   @UseGuards(AuthGuard('jwt'))
+  @Get('history')
+  async getUserCompletedSessions(@Req() req: AuthenticatedRequest) {
+    return this.trainingSessionService.getCompletedSessionsByUser(req.user.id);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
   @Get(':id')
   async getSessionById(@Param('id') id: number) {
     const session = await this.trainingSessionService.getSessionById(
@@ -22,14 +28,9 @@ export class TrainingSessionController {
     }
     return session;
   }
+
   @Patch(':id/complete')
   async completeSession(@Param('id') id: string) {
     return this.trainingSessionService.markComplete(+id);
-  }
-
-  @UseGuards(AuthGuard('jwt'))
-  @Get('history')
-  async getUserCompletedSessions(@Req() req: AuthenticatedRequest) {
-    return this.trainingSessionService.getCompletedSessionsByUser(req.user.id);
   }
 }

--- a/switkor-backend/src/training-session/training-session.controller.ts
+++ b/switkor-backend/src/training-session/training-session.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Param, UseGuards, Patch } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards, Patch, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { TrainingSessionService } from './training-session.service';
 import { AuthGuard } from '@nestjs/passport';
 import { NotFoundException } from '@nestjs/common';
+import { AuthenticatedRequest } from '../types/express';
 
 @Controller('session')
 export class TrainingSessionController {
@@ -23,5 +25,11 @@ export class TrainingSessionController {
   @Patch(':id/complete')
   async completeSession(@Param('id') id: string) {
     return this.trainingSessionService.markComplete(+id);
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('history')
+  async getUserCompletedSessions(@Req() req: AuthenticatedRequest) {
+    return this.trainingSessionService.getCompletedSessionsByUser(req.user.id);
   }
 }

--- a/switkor-backend/src/training-session/training-session.entity.ts
+++ b/switkor-backend/src/training-session/training-session.entity.ts
@@ -40,4 +40,7 @@ export class TrainingSession {
 
   @OneToMany(() => TrainingExercise, (exercise) => exercise.session)
   exercises: TrainingExercise[];
+
+  @Column({ default: false })
+  completed: boolean;
 }

--- a/switkor-backend/src/training-session/training-session.service.ts
+++ b/switkor-backend/src/training-session/training-session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TrainingSession } from './training-session.entity';
@@ -9,7 +9,7 @@ export class TrainingSessionService {
     @InjectRepository(TrainingSession)
     private readonly sessionRepo: Repository<TrainingSession>,
   ) {}
-
+  //devuelve sesión por su Id
   async getSessionById(id: number, userId?: number): Promise<TrainingSession> {
     const session = await this.sessionRepo.findOne({
       where: {
@@ -26,5 +26,34 @@ export class TrainingSessionService {
     }
 
     return session;
+  }
+  //marca sesión como completada
+  async markComplete(id: number): Promise<TrainingSession> {
+    const session = await this.sessionRepo.findOne({ where: { id } });
+    if (!session) {
+      throw new NotFoundException(`Sesión con id ${id} no encontrada.`);
+    }
+
+    // comparar sólo la parte de fecha (sin horas)
+    const today = new Date();
+    const sessionDate = new Date(session.date);
+    const isSameDay =
+      today.getFullYear() === sessionDate.getFullYear() &&
+      today.getMonth() === sessionDate.getMonth() &&
+      today.getDate() === sessionDate.getDate();
+
+    if (!isSameDay) {
+      const fechaStr = sessionDate.toLocaleDateString('es-ES', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      });
+      throw new BadRequestException(
+        `Hoy no toca completar esta sesión. La sesión es el ${fechaStr}.`
+      );
+    }
+
+    session.completed = true;
+    return this.sessionRepo.save(session);
   }
 }

--- a/switkor-backend/src/training-session/training-session.service.ts
+++ b/switkor-backend/src/training-session/training-session.service.ts
@@ -56,4 +56,20 @@ export class TrainingSessionService {
     session.completed = true;
     return this.sessionRepo.save(session);
   }
+
+  async getCompletedSessionsByUser(userId: number): Promise<TrainingSession[]> {
+  return this.sessionRepo.find({
+    where: {
+      completed: true,
+      trainingPlan: {
+        user: { id: userId },
+      },
+    },
+    relations: ['trainingPlan'],
+    order: {
+      date: 'ASC',
+    },
+  });
+}
+
 }

--- a/switkor-backend/src/types/express.d.ts
+++ b/switkor-backend/src/types/express.d.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express';
+import { User } from '../../user/user.entity'; // ajusta la ruta
+
+export interface AuthenticatedRequest extends Request {
+  user: User;
+}

--- a/switkor-frontend/src/app/dashboard/page.tsx
+++ b/switkor-frontend/src/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ interface Session {
   weekNumber: number;
   focus: string;
   sessionType: string;
+  completed: boolean; 
 }
 
 interface Plan {
@@ -26,12 +27,11 @@ export default function DashboardPage() {
   const router = useRouter();
   const token = useAuthStore((state) => state.token);
   const logout = useAuthStore((state) => state.logout);
-  const [sessionsByDate, setSessionsByDate] = useState<
-    Record<
-      string,
-      { id: number; label: string; focus: string; sessionType: string }
-    >
-  >({});
+  const [sessionsByDate, setSessionsByDate] = useState<Record<
+    string,
+    { id: number; label: string; focus: string; sessionType: string; completed: boolean; }
+  > | null>(null);
+
   const [nextSessionDate, setNextSessionDate] = useState<string | null>(null);
   const [nextSessionId, setNextSessionId] = useState<number | null>(null);
   const formatDateKey = (date: Date) => date.toLocaleDateString("sv-SE"); // 'YYYY-MM-DD'
@@ -48,7 +48,7 @@ export default function DashboardPage() {
 
         const sessionsMap: Record<
           string,
-          { id: number; label: string; focus: string; sessionType: string }
+          { id: number; label: string; focus: string; sessionType: string; completed:boolean;}
         > = {};
         plan.sessions?.forEach((session) => {
           const date = formatDateKey(new Date(session.date));
@@ -57,6 +57,7 @@ export default function DashboardPage() {
             label: `Semana ${session.weekNumber}`,
             focus: session.focus,
             sessionType: session.sessionType,
+            completed: session.completed,
           };
         });
 
@@ -64,13 +65,15 @@ export default function DashboardPage() {
 
         const now = new Date();
 
-        const futureSession = plan.sessions?.find((s) => {
-          const sessionStart = new Date(s.date); // ej. 2025-06-19T00:00:00
-          const sessionEnd = new Date(sessionStart); // clonamos
-          sessionEnd.setHours(23, 59, 59, 999); // la sesión expira a las 23:59:59.999
+        const futureSession = plan.sessions
+          ?.filter((s) => !s.completed) //  ◀︎ excluye las completadas
+          .find((s) => {
+            const sessionStart = new Date(s.date); // ej. 2025-06-19T00:00:00
+            const sessionEnd = new Date(sessionStart); // clonamos
+            sessionEnd.setHours(23, 59, 59, 999); // la sesión expira a las 23:59:59.999
 
-          return sessionEnd >= now;
-        });
+            return sessionEnd >= now;
+          });
 
         if (futureSession) {
           setNextSessionDate(formatDateKey(new Date(futureSession.date)));
@@ -78,12 +81,21 @@ export default function DashboardPage() {
         }
       } catch (err) {
         console.error("Error al cargar el plan:", err);
+        setSessionsByDate({});
       }
     };
 
     if (token) fetchPlan();
   }, [token]);
 
+  // Si aún estamos esperando la respuesta, mostramos un loader
+  if (sessionsByDate === null) {
+    return (
+      <main className="flex items-center justify-center h-screen">
+        <p className="text-lg text-sky-900">Cargando tu plan…</p>
+      </main>
+    );
+  }
   const handleLogout = () => {
     logout();
     router.push("/login");
@@ -166,7 +178,7 @@ export default function DashboardPage() {
         <h2 className="text-xl font-semibold mb-4 text-sky-900">
           Tu calendario de entrenamiento
         </h2>
-        {Object.keys(sessionsByDate).length === 0 && (
+        {sessionsByDate && Object.keys(sessionsByDate).length === 0 && (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-xl mt-4 text-center text-base font-semibold mb-4">
             ⚠️ No tienes planes activos. Crea uno para comenzar.
           </div>

--- a/switkor-frontend/src/app/dashboard/page.tsx
+++ b/switkor-frontend/src/app/dashboard/page.tsx
@@ -49,12 +49,13 @@ export default function DashboardPage() {
   const [chartData, setChartData] = useState<
     { month: string; count: number }[]
   >([]);
-  const today = new Date();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         if (!token) return;
+        
+        const today = new Date();
         
         const planRes = await api.get<Plan[]>("/plan/current-and-previous");
         const plans: Plan[] = planRes.data;

--- a/switkor-frontend/src/app/dashboard/page.tsx
+++ b/switkor-frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,9 @@ import { PlusIcon, LogOutIcon } from "lucide-react";
 import { api } from "@/lib/api";
 import CustomCalendar from "@/components/CustomCalendar";
 import MobileMenu from "@/components/mobileMenu";
+import { subMonths, format } from "date-fns";
+import { es } from "date-fns/locale";
+import TrainingHistoryChart from "@/components/TrainingHistoryChart";
 
 interface Session {
   id: number;
@@ -16,7 +19,7 @@ interface Session {
   weekNumber: number;
   focus: string;
   sessionType: string;
-  completed: boolean; 
+  completed: boolean;
 }
 
 interface Plan {
@@ -29,30 +32,49 @@ export default function DashboardPage() {
   const logout = useAuthStore((state) => state.logout);
   const [sessionsByDate, setSessionsByDate] = useState<Record<
     string,
-    { id: number; label: string; focus: string; sessionType: string; completed: boolean; }
+    {
+      id: number;
+      label: string;
+      focus: string;
+      sessionType: string;
+      completed: boolean;
+    }
   > | null>(null);
 
   const [nextSessionDate, setNextSessionDate] = useState<string | null>(null);
   const [nextSessionId, setNextSessionId] = useState<number | null>(null);
   const formatDateKey = (date: Date) => date.toLocaleDateString("sv-SE"); // 'YYYY-MM-DD'
   const username = useAuthStore((state) => state.name || "");
+  const [streak, setStreak] = useState<number>(0);
+  const [chartData, setChartData] = useState<
+    { month: string; count: number }[]
+  >([]);
+  const today = new Date();
 
   useEffect(() => {
-    const fetchPlan = async () => {
+    const fetchData = async () => {
       try {
-        const res = await api.get<Plan>("/plan/current");
-        //debug
-        console.log("Respuesta del backend:", res.data);
-        //debug
-        const plan = res.data;
+        if (!token) return;
+        
+        const planRes = await api.get<Plan[]>("/plan/current-and-previous");
+        const plans: Plan[] = planRes.data;
 
         const sessionsMap: Record<
           string,
-          { id: number; label: string; focus: string; sessionType: string; completed:boolean;}
+          {
+            id: number;
+            label: string;
+            focus: string;
+            sessionType: string;
+            completed: boolean;
+          }
         > = {};
-        plan.sessions?.forEach((session) => {
-          const date = formatDateKey(new Date(session.date));
-          sessionsMap[date] = {
+        
+        const allSessions: Session[] = plans.flatMap((p: Plan) => p.sessions || []);
+
+        allSessions.forEach((session) => {
+          const key = formatDateKey(new Date(session.date));
+          sessionsMap[key] = {
             id: session.id,
             label: `Semana ${session.weekNumber}`,
             focus: session.focus,
@@ -63,31 +85,61 @@ export default function DashboardPage() {
 
         setSessionsByDate(sessionsMap);
 
-        const now = new Date();
+        
 
-        const futureSession = plan.sessions
-          ?.filter((s) => !s.completed) //  ◀︎ excluye las completadas
+        // Próxima sesión no completada
+        const future = allSessions
+          .filter((s) => !s.completed)
           .find((s) => {
-            const sessionStart = new Date(s.date); // ej. 2025-06-19T00:00:00
-            const sessionEnd = new Date(sessionStart); // clonamos
-            sessionEnd.setHours(23, 59, 59, 999); // la sesión expira a las 23:59:59.999
-
-            return sessionEnd >= now;
+            const start = new Date(s.date);
+            const end = new Date(start);
+            end.setHours(23, 59, 59, 999);
+            return end >= today;
           });
 
-        if (futureSession) {
-          setNextSessionDate(formatDateKey(new Date(futureSession.date)));
-          setNextSessionId(futureSession.id);
+        if (future) {
+          setNextSessionDate(formatDateKey(new Date(future.date)));
+          setNextSessionId(future.id);
         }
+        // 🆕 Obtener sesiones completadas del historial completo
+        const historyRes = await api.get<Session[]>("/session/history");
+        const completedSessions = historyRes.data;
+
+        // 🆕 Calcular racha real desde sesiones históricas
+        const sorted = completedSessions
+          .map((s) => ({ ...s, dateObj: new Date(s.date) }))
+          .sort((a, b) => b.dateObj.getTime() - a.dateObj.getTime());
+
+        let count = 0;
+        for (const s of sorted) {
+          if (s.dateObj > today) continue;
+          if (s.completed) count++;
+          else break;
+        }
+        setStreak(count);
+
+        // 🆕 Calcular datos para gráfica últimos 6 meses
+        const data: { month: string; count: number }[] = [];
+        for (let i = 5; i >= 0; i--) {
+          const date = subMonths(new Date(), i);
+          const monthLabel = format(date, "MMM yyyy", { locale: es });
+          const cnt = completedSessions.filter((s) => {
+            const d = new Date(s.date);
+            return (
+              d.getMonth() === date.getMonth() &&
+              d.getFullYear() === date.getFullYear()
+            );
+          }).length;
+          data.push({ month: monthLabel, count: cnt });
+        }
+        setChartData(data);
       } catch (err) {
-        console.error("Error al cargar el plan:", err);
-        setSessionsByDate({});
+        console.error("Error al cargar datos:", err);
       }
     };
 
-    if (token) fetchPlan();
+    fetchData();
   }, [token]);
-
   // Si aún estamos esperando la respuesta, mostramos un loader
   if (sessionsByDate === null) {
     return (
@@ -102,8 +154,8 @@ export default function DashboardPage() {
   };
 
   const handleDayClick = (value: Date) => {
-    const iso = formatDateKey(value);
-    const sessionInfo = sessionsByDate[iso];
+    const key = formatDateKey(value);
+    const sessionInfo = sessionsByDate[key];
     if (sessionInfo) {
       router.push(`/dashboard/session/${sessionInfo.id}`);
     }
@@ -173,8 +225,7 @@ export default function DashboardPage() {
           </div>
         )}
       </section>
-
-      <section className="bg-gray-100 rounded-3xl py-6 px-2 sm:px-16 shadow-md mt-4">
+      <section className="bg-gray-100 rounded-3xl py-6 px-2 sm:px-10 lg:px-16 xl:px-24 shadow-md mt-4 max-w-7xl mx-auto">
         <h2 className="text-xl font-semibold mb-4 text-sky-900">
           Tu calendario de entrenamiento
         </h2>
@@ -183,10 +234,26 @@ export default function DashboardPage() {
             ⚠️ No tienes planes activos. Crea uno para comenzar.
           </div>
         )}
-        <CustomCalendar
-          sessionsByDate={sessionsByDate}
-          onClickDay={handleDayClick}
-        />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+          {/* Calendario */}
+          <div className="w-full max-w-md lg:max-w-lg xl:max-w-xl mx-auto">
+            <CustomCalendar
+              sessionsByDate={sessionsByDate}
+              onClickDay={handleDayClick}
+            />
+          </div>
+
+          {/* Racha y gráfica */}
+          <div className="w-full max-w-[500px] flex flex-col items-center self-center">
+            <div className="mt-4 px-4 py-2 bg-blue-50 border border-blue-200 text-blue-700 rounded-lg text-center text-base sm:text-lg w-full max-w-md">
+              Llevas una racha de <strong>{streak}</strong> entrenamientos sin
+              fallar. 🎉
+            </div>
+            <div className="mt-6 w-full">
+              <TrainingHistoryChart data={chartData} />
+            </div>
+          </div>
+        </div>
       </section>
       <div className="mt-4 mb-8 flex gap-6 justify-center text-sm text-gray-700">
         <div className="flex items-center gap-2">
@@ -200,4 +267,12 @@ export default function DashboardPage() {
       </div>
     </main>
   );
+}
+{
+  /* para que solo aparezca cuando al menos llevas una
+        {streak > 0 && (
+        <div className="mt-4 …">
+          Llevas una racha de <strong>{streak}</strong> entrenamientos sin fallar. 🎉
+        </div>
+        )} */
 }

--- a/switkor-frontend/src/app/dashboard/session/[id]/page.tsx
+++ b/switkor-frontend/src/app/dashboard/session/[id]/page.tsx
@@ -157,6 +157,12 @@ export default function SessionPage() {
               </button>
             </div>
           )}
+          {/* Mensaje verde si ya completada */}
+          {session.completed && (
+            <div className="mb-4 flex items-center bg-green-100 border border-green-400 text-green-700 px-4 py-2 rounded">
+              <span>Esta sesión ya fue completada 💪</span>
+            </div>
+          )}   
           {/* Card gris*/}
           <div className=" bg-gray-50 rounded-3xl p-4 sm:p-6 shadow-inner px-1 sm:px-6">
             {/* Etiquetas */}

--- a/switkor-frontend/src/app/dashboard/session/[id]/page.tsx
+++ b/switkor-frontend/src/app/dashboard/session/[id]/page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import { useAuthStore } from "@/store/auth-store";
 import Link from "next/link";
 import { ArrowLeftIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
-import { patternTranslations } from '@/lib/patternTranslations';
-import { goalTranslations } from '@/lib/goalTranslations';
-import type { Session, Exercise } from '@/types/plan';
-
+import { patternTranslations } from "@/lib/patternTranslations";
+import { goalTranslations } from "@/lib/goalTranslations";
+import type { Session, Exercise } from "@/types/plan";
 
 export default function SessionPage() {
   const { id } = useParams();
+  const router = useRouter();
   const token = useAuthStore((state) => state.token);
   const [session, setSession] = useState<Session | null>(null);
+  const [marking, setMarking] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchSession = async () => {
@@ -35,6 +37,40 @@ export default function SessionPage() {
     if (typeof id === "string" && token) fetchSession();
   }, [id, token]);
 
+  // Limpia el mensaje de error tras 5 segundos
+  useEffect(() => {
+    if (!errorMessage) return;
+    const timer = setTimeout(() => setErrorMessage(null), 5000);
+    return () => clearTimeout(timer);
+  }, [errorMessage]);
+
+  // Función para marcar sesión como completada
+  const handleComplete = () => {
+    if (!session) return;
+    const today = new Date().toDateString();
+    const sessionDay = new Date(session.date).toDateString();
+    if (today !== sessionDay) {
+      setErrorMessage(
+        `Hoy no toca completar esta sesión. La sesión es el ${new Date(
+          session.date
+        ).toLocaleDateString("es-ES")}`
+      );
+      return;
+    }
+    // proceed to mark
+    setErrorMessage(null);
+    setMarking(true);
+    api
+      .patch(`/session/${id}/complete`, null, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then(() => router.push("/dashboard"))
+      .catch((err) => {
+        console.error("Error marcando completada:", err);
+        setErrorMessage("No se pudo completar. Inténtalo más tarde.");
+        setMarking(false);
+      });
+  };
   if (!session) {
     return (
       <div className="h-screen flex items-center justify-center text-sky-900 font-medium">
@@ -86,7 +122,6 @@ export default function SessionPage() {
         </div>
 
         {/* Claim */}
-
         <p className="mb-2 text-center text-lg sm:text-2xl font-semibold text-sky-900">
           ¡Hoy es un buen día para entrenar!
         </p>
@@ -97,47 +132,73 @@ export default function SessionPage() {
           <h1 className="text-lg sm:text-2xl font-bold text-center text-sky-900 mb-4 sm:mb-6">
             {session.dayOfWeek} - {new Date(session.date).toLocaleDateString()}
           </h1>
+          {/* Checkbox para completar sesion */}
+          <label className="flex items-center space-x-2 mb-4">
+            <input
+              type="checkbox"
+              checked={session.completed}
+              onChange={handleComplete}
+              disabled={marking}
+              className="form-checkbox h-5 w-5 text-emerald-500"
+            />
+            <span className="text-sm font-medium">Completada</span>
+          </label>
+
+          {/* Mostrar error si la petición devuelve 400 */}
+          {errorMessage && (
+            <div className="mb-4 flex justify-between items-center bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded">
+              <span>{errorMessage}</span>
+              {/* Aquí está el botón de cierre */}
+              <button
+                onClick={() => setErrorMessage(null)}
+                className="font-bold ml-4"
+              >
+                ×
+              </button>
+            </div>
+          )}
           {/* Card gris*/}
           <div className=" bg-gray-50 rounded-3xl p-4 sm:p-6 shadow-inner px-1 sm:px-6">
-              {/* Etiquetas */}
-              <div className="flex justify-center gap-2 mb-4 sm:mb-6 flex-wrap">
-                <span className="px-3 py-1 bg-rose-100 text-rose-600 font-medium rounded-full text-xs sm:text-sm">
-                  {goalTranslations[session.trainingPlan.goal] || session.trainingPlan.goal}
-                </span>
-                <span className="px-3 py-1 bg-indigo-100 text-indigo-600 font-medium rounded-full text-xs sm:text-sm">
-                  {session.focus
-                    .split(",")
-                    .map((key) => patternTranslations[key.trim()] || key)
-                    .join(" / ")}
-                </span>
-              </div>
-              {/* Bloques de ejercicios */}
-              <div className="space-y-6 sm:space-y-8 m-0">
-                {Object.entries(groupedExercises).map(([block, exercises]) => (
-                  <div
-                    key={block}
-                    className="bg-emerald-50 border border-emerald-100 rounded-2xl sm:rounded-3xl shadow p-4 sm:p-8"
-                  >
-                    <h2 className=" text-base sm:text-lg font-semibold text-emerald-800 mb-3 sm:mb-4">
-                      {blockTitles[block] || block}
-                    </h2>
-                    <ul className="space-y-1 sm:space-y-2">
-                      {exercises.map((ex, index) => (
-                        <li
-                          key={index}
-                          className="flex justify-between items-center text-responsive"
-                        >
-                          <span>🔹{ex.exercise.name}</span>
-                          <span className="font-medium">
-                            {ex.sets}x{ex.reps}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
+            {/* Etiquetas */}
+            <div className="flex justify-center gap-2 mb-4 sm:mb-6 flex-wrap">
+              <span className="px-3 py-1 bg-rose-100 text-rose-600 font-medium rounded-full text-xs sm:text-sm">
+                {goalTranslations[session.trainingPlan.goal] ||
+                  session.trainingPlan.goal}
+              </span>
+              <span className="px-3 py-1 bg-indigo-100 text-indigo-600 font-medium rounded-full text-xs sm:text-sm">
+                {session.focus
+                  .split(",")
+                  .map((key) => patternTranslations[key.trim()] || key)
+                  .join(" / ")}
+              </span>
             </div>
+            {/* Bloques de ejercicios */}
+            <div className="space-y-6 sm:space-y-8 m-0">
+              {Object.entries(groupedExercises).map(([block, exercises]) => (
+                <div
+                  key={block}
+                  className="bg-emerald-50 border border-emerald-100 rounded-2xl sm:rounded-3xl shadow p-4 sm:p-8"
+                >
+                  <h2 className=" text-base sm:text-lg font-semibold text-emerald-800 mb-3 sm:mb-4">
+                    {blockTitles[block] || block}
+                  </h2>
+                  <ul className="space-y-1 sm:space-y-2">
+                    {exercises.map((ex, index) => (
+                      <li
+                        key={index}
+                        className="flex justify-between items-center text-responsive"
+                      >
+                        <span>🔹{ex.exercise.name}</span>
+                        <span className="font-medium">
+                          {ex.sets}x{ex.reps}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </main>
     </div>

--- a/switkor-frontend/src/app/globals.css
+++ b/switkor-frontend/src/app/globals.css
@@ -83,6 +83,19 @@ body {
   color: #166534; /* verde intenso */
 }
 
+/* Sesiones completadas: verde azulado suave */
+.react-calendar__tile.tile-completed {
+  background-color: #bae6fd;    /* sky-200, un celeste suave */
+  color: #065f46 !important;    /* emerald-800 para buen contraste */
+  border-radius: 0.75rem !important;
+  opacity: 0.9;
+}
+
+/* Hover más pronunciado */
+.react-calendar__tile.tile-completed:hover {
+  background-color: #7dd3fc;    /* sky-300 */
+  opacity: 1;
+}
 
 /* Texto responsive en tres tamaños */
 @media (max-width: 450px) {

--- a/switkor-frontend/src/components/CustomCalendar.tsx
+++ b/switkor-frontend/src/components/CustomCalendar.tsx
@@ -6,7 +6,7 @@ import 'react-tooltip/dist/react-tooltip.css';
 import { patternTranslations } from '@/lib/patternTranslations';
 
 interface CustomCalendarProps {
-  sessionsByDate: Record<string,  { id: number; label: string; focus: string; sessionType: string }>;
+  sessionsByDate: Record<string,  { id: number; label: string; focus: string; sessionType: string; completed: boolean }>;
   onClickDay: (value: Date) => void;
 }
 
@@ -24,7 +24,7 @@ export default function CustomCalendar({ sessionsByDate, onClickDay }: CustomCal
         .map((key) => patternTranslations[key.trim()] || key)
         .join(' / ');
 
-        const emoji = session.sessionType === 'recovery' ? '🧘' : '🏋️';
+        const icon = session.completed ? '✔️' : session.sessionType === 'recovery' ? '🧘' : '🏋️';
 
       return (
         <div
@@ -32,7 +32,7 @@ export default function CustomCalendar({ sessionsByDate, onClickDay }: CustomCal
           data-tooltip-content={translatedFocus}
           className="text-lg text-emerald-700 emoji-session"
         >
-          {emoji}
+          {icon}
         </div>
       );
     }
@@ -43,35 +43,35 @@ export default function CustomCalendar({ sessionsByDate, onClickDay }: CustomCal
   const iso = formatDateKey(date);
   const session = sessionsByDate[iso];
 
-  //debug
-   if (session) {
-    console.log(iso, session.sessionType); 
-  }
-  //debug
+  
   if (!session) return null;
 
-  if (session.sessionType === 'recovery') return ['tile-recovery'];
-  return ['tile-main'];; // todo lo que no sea recovery se considera sesión normal
+ if (session.completed) return ['tile-completed'];
+    if (session.sessionType === 'recovery') return ['tile-recovery'];
+    return ['tile-main']; 
   };
   return (
-    <div className="w-full sm:max-w-3xl sm:mx-auto px-0 scale-90 sm:scale-85 sm:origin-top">
-      <Calendar
-        onClickDay={onClickDay}
-        tileContent={tileContent}
-        tileClassName={tileClassName}
-        prevLabel={<span className="text-emerald-600 text-3xl font-bold ml-2 me-2">{'‹'}</span>}
-        nextLabel={<span className="text-emerald-600 text-3xl font-bold mr-2 ms-2">{'›'}</span>}
-        prev2Label={null}
-        next2Label={null}
-        navigationLabel={({ label }) => (
-          <span className="text-base sm:text-lg font-semibold mx-4">
-            {label}
-          </span>
-        )}
-        
-        className="!border-none p-4 rounded-3xl shadow-md bg-white"
-      />
-      <Tooltip id="session-tooltip" />
+    <div className="w-full sm:max-w-3xl sm:mx-auto px-0 flex justify-center">
+        <div className="origin-top inline-block">
+          <Calendar
+            onClickDay={onClickDay}
+            tileContent={tileContent}
+            tileClassName={tileClassName}
+            prevLabel={<span className="text-emerald-600 text-3xl font-bold ml-2 me-2">{'‹'}</span>}
+            nextLabel={<span className="text-emerald-600 text-3xl font-bold mr-2 ms-2">{'›'}</span>}
+            prev2Label={null}
+            next2Label={null}
+            navigationLabel={({ label }) => (
+              <span className="text-base sm:text-lg font-semibold mx-4">
+                {label}
+              </span>
+            )}
+            
+            className="!border-none p-4 rounded-3xl shadow-md bg-white"
+          />
+          <Tooltip id="session-tooltip" />
+        </div>
     </div>
+     
   );
 }

--- a/switkor-frontend/src/components/TrainingHistoryChart.tsx
+++ b/switkor-frontend/src/components/TrainingHistoryChart.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip as RechartTooltip,
+} from 'recharts';
+
+interface TrainingHistoryChartProps {
+  // Datos ya preparados: último array de { month, count }
+  data: { month: string; count: number }[];
+}
+
+export default function TrainingHistoryChart({ data }: TrainingHistoryChartProps) {
+  return (
+    <div className="mt-6 h-56">
+      {/* Gráfica de barras para los últimos 6 meses */}
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={data}
+          margin={{ top: 20, bottom: 20 }}
+          barSize={20}            // Barras más estrechas
+          barCategoryGap="30%"     // Espacio entre barras
+        >
+
+           {/* Eje X con etiquetas sky-900 y líneas de eje más gruesas */}
+          <XAxis
+            dataKey="month"
+            tick={{
+              fill: '#0c4a6e',      // text-sky-900
+              fontSize: 12,
+              fontWeight: 'bold',
+            }}
+            axisLine={{ stroke: '#0c4a6e', strokeWidth: 2 }}
+            tickLine={{ stroke: '#0c4a6e', strokeWidth: 1 }}
+            interval={0}
+            angle={-30}
+            textAnchor="end"
+          />
+
+          {/* Eje Y con líneas y ticks sky-900 */}
+          <YAxis
+            allowDecimals={false}
+            axisLine={{ stroke: '#0c4a6e', strokeWidth: 2 }}
+            tickLine={{ stroke: '#0c4a6e', strokeWidth: 1 }}
+            tick={{ fill: '#0c4a6e', fontSize: 12 }}
+          />
+
+          <RechartTooltip formatter={(value: number) => `${value} sesiones`} />
+
+          {/* Barras estándar, color azul intenso */}
+          <Bar
+            dataKey="count"
+            fill="#3b82f6"
+            radius={[4, 4, 0, 0]}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/switkor-frontend/src/types/plan.ts
+++ b/switkor-frontend/src/types/plan.ts
@@ -17,6 +17,7 @@ export interface Session {
   focus: string;
   trainingPlan: {goal: 'health' | 'strength' | 'muscle_gain';};
   exercises: Exercise[];
+  completed: boolean;
 }
 
 export interface Plan {

--- a/switkor-frontend/src/types/recharts.d.ts
+++ b/switkor-frontend/src/types/recharts.d.ts
@@ -1,0 +1,1 @@
+declare module 'recharts';


### PR DESCRIPTION
En esta pull se añade:
-numero de sesiones completadas sin fachar, racha.
-conteo de sesiones completadas en cada mes (ultimos 6 meses)
-label con la rachas que llevas y grafica con sesiones de cada mes
-se añade un endpoint para mostrar, además del plan activo, el plan anterior.

**falta por probar como se comporta cuando marcas una sesión como completada